### PR TITLE
Add LLaMA 3.1 configuration and model

### DIFF
--- a/lavis/configs/models/blip2/blip2_pretrain_llama3.1.yaml
+++ b/lavis/configs/models/blip2/blip2_pretrain_llama3.1.yaml
@@ -1,0 +1,42 @@
+ # Copyright (c) 2022, salesforce.com, inc.
+ # All rights reserved.
+ # SPDX-License-Identifier: BSD-3-Clause
+ # For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+
+model:
+  arch: blip2_llama
+  load_finetuned: False
+  
+  pretrained: "https://storage.googleapis.com/sfr-vision-language-research/LAVIS/models/BLIP2/blip2_pretrained.pth"
+  finetuned: ""
+
+  # vit encoder
+  image_size: 224
+  drop_path_rate: 0
+  use_grad_checkpoint: False
+  vit_precision: "fp16"
+  freeze_vit: True
+
+  # Q-Former
+  num_query_token: 32
+
+  # LLM
+  llm_model: "./llm/llama-3.1"
+
+  # generation configs
+  prompt: ""
+
+
+preprocess:
+    vis_processor:
+        train:
+          name: "blip2_image_train"
+          image_size: 224
+        eval:
+          name: "blip_image_eval"
+          image_size: 224
+    text_processor:
+        train:
+          name: "blip_caption"
+        eval:
+          name: "blip_caption"

--- a/lavis/models/__init__.py
+++ b/lavis/models/__init__.py
@@ -33,6 +33,7 @@ from lavis.models.blip_models.blip_vqa import BlipVQA
 
 from lavis.models.blip2_models.blip2 import Blip2Base
 from lavis.models.blip2_models.blip2_opt import Blip2OPT
+from lavis.models.blip2_models.blip2_llama import Blip2Llama
 from lavis.models.blip2_models.blip2_t5 import Blip2T5
 from lavis.models.blip2_models.blip2_qformer import Blip2Qformer
 from lavis.models.blip2_models.blip2_image_text_matching import Blip2ITM
@@ -80,6 +81,7 @@ __all__ = [
     "Blip2Base",
     "Blip2ITM",
     "Blip2OPT",
+    "Blip2Llama",
     "Blip2T5",
     "Blip2T5Instruct",
     "Blip2VicunaInstruct",

--- a/lavis/models/blip2_models/blip2_llama.py
+++ b/lavis/models/blip2_models/blip2_llama.py
@@ -1,0 +1,419 @@
+"""
+ Copyright (c) 2023, salesforce.com, inc.
+ All rights reserved.
+ SPDX-License-Identifier: BSD-3-Clause
+ For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+"""
+import logging
+from packaging import version
+
+import torch
+from torch.cuda.amp import autocast as autocast
+import torch.nn as nn
+
+from lavis.common.registry import registry
+from lavis.models.blip2_models.blip2 import Blip2Base, disabled_train
+from transformers import LlamaTokenizer
+from lavis.models.blip2_models.modeling_llama import LlamaForCausalLM
+import transformers
+
+
+@registry.register_model("blip2_llama")
+class Blip2Llama(Blip2Base):
+    """
+    BLIP2 LLaMA model.
+    Supported model types:
+        - pretrain_llama3.1: pretrained model with LLaMA 3.1
+    Usage:
+        >>> from lavis.models import load_model
+        >>> model = load_model("blip2_llama", "pretrain_llama3.1")
+    """
+
+    PRETRAINED_MODEL_CONFIG_DICT = {
+        "pretrain_llama3.1": "configs/models/blip2/blip2_pretrain_llama3.1.yaml",
+    }
+
+    def __init__(
+        self,
+        vit_model="eva_clip_g",
+        img_size=224,
+        drop_path_rate=0,
+        use_grad_checkpoint=False,
+        vit_precision="fp16",
+        freeze_vit=True,
+        num_query_token=32,
+        llm_model="facebook/llama-3.1",
+        prompt="",
+        max_txt_len=32,
+        apply_lemmatizer=False,
+    ):
+        """
+        apply_lemmatizer: when set to True, postprocess predict_answers() result with lemmas.
+        """
+        super().__init__()
+        transformers_version = version.parse(transformers.__version__)
+        assert transformers_version >= version.parse("4.28"), "BLIP-2 LLaMA requires transformers>=4.28"
+        
+        self.tokenizer = self.init_tokenizer()
+
+        self.visual_encoder, self.ln_vision = self.init_vision_encoder(
+            vit_model, img_size, drop_path_rate, use_grad_checkpoint, vit_precision
+        )
+        if freeze_vit:
+            for name, param in self.visual_encoder.named_parameters():
+                param.requires_grad = False
+            self.visual_encoder = self.visual_encoder.eval()
+            self.visual_encoder.train = disabled_train
+            logging.info("freeze vision encoder")
+
+        self.Qformer, self.query_tokens = self.init_Qformer(
+            num_query_token, self.visual_encoder.num_features
+        )
+        self.Qformer.cls = None
+        self.Qformer.bert.embeddings.word_embeddings = None
+        self.Qformer.bert.embeddings.position_embeddings = None
+        for layer in self.Qformer.bert.encoder.layer:
+            layer.output = None
+            layer.intermediate = None
+
+        self.opt_tokenizer = LlamaTokenizer.from_pretrained(llm_model, use_fast=False)
+        self.opt_model = LlamaForCausalLM.from_pretrained(
+            llm_model, torch_dtype=torch.float16
+        )
+        for name, param in self.opt_model.named_parameters():
+            param.requires_grad = False
+        self.eos_token_id = self.opt_tokenizer(
+            "\n", add_special_tokens=False
+        ).input_ids[0]
+
+        self.opt_proj = nn.Linear(
+            self.Qformer.config.hidden_size, self.opt_model.config.hidden_size
+        )
+
+        self.max_txt_len = max_txt_len
+        self.prompt = prompt
+        prompt_tokens = self.opt_tokenizer(self.prompt, return_tensors="pt")
+        self.prompt_length = prompt_tokens.attention_mask.sum(1)
+        
+        self._apply_lemmatizer = apply_lemmatizer
+        self._lemmatizer = None       
+
+    def forward(self, samples):
+        image = samples["image"]
+        with self.maybe_autocast():
+            image_embeds = self.ln_vision(self.visual_encoder(image))
+        image_atts = torch.ones(image_embeds.size()[:-1], dtype=torch.long).to(
+            image.device
+        )
+
+        query_tokens = self.query_tokens.expand(image_embeds.shape[0], -1, -1)
+        query_output = self.Qformer.bert(
+            query_embeds=query_tokens,
+            encoder_hidden_states=image_embeds,
+            encoder_attention_mask=image_atts,
+            return_dict=True,
+        )
+
+        inputs_opt = self.opt_proj(query_output.last_hidden_state)
+        atts_opt = torch.ones(inputs_opt.size()[:-1], dtype=torch.long).to(image.device)
+
+        self.opt_tokenizer.padding_side = "right"
+
+        text = [t + "\n" for t in samples["text_input"]]
+
+        opt_tokens = self.opt_tokenizer(
+            text,
+            return_tensors="pt",
+            padding="longest",
+            truncation=True,
+            max_length=self.max_txt_len,
+        ).to(image.device)
+
+        targets = opt_tokens.input_ids.masked_fill(
+            opt_tokens.input_ids == self.opt_tokenizer.pad_token_id, -100
+        )
+        if self.prompt:
+            targets[:, : self.prompt_length] = -100  # do not apply loss to the prompt
+
+        empty_targets = (
+            torch.ones(atts_opt.size(), dtype=torch.long).to(image.device).fill_(-100)
+        )
+        targets = torch.cat([empty_targets, targets], dim=1)
+
+        inputs_embeds = self.opt_model.model.decoder.embed_tokens(opt_tokens.input_ids)
+        inputs_embeds = torch.cat([inputs_opt, inputs_embeds], dim=1)
+        attention_mask = torch.cat([atts_opt, opt_tokens.attention_mask], dim=1)
+
+        with self.maybe_autocast():
+            outputs = self.opt_model(
+                inputs_embeds=inputs_embeds,
+                attention_mask=attention_mask,
+                return_dict=True,
+                labels=targets,
+            )
+        loss = outputs.loss
+
+        return {"loss": loss}
+
+    @torch.no_grad()
+    def generate(
+        self,
+        samples,
+        use_nucleus_sampling=False,
+        num_beams=5,
+        max_length=30,
+        min_length=1,
+        top_p=0.9,
+        repetition_penalty=1.0,
+        length_penalty=1.0,
+        num_captions=1,
+        temperature=1,
+    ):
+        """
+        Args:
+            samples (dict): A dictionary containing the following keys:
+                - image (torch.Tensor): A tensor of shape (batch_size, 3, H, W)
+            use_nucleus_sampling (bool): Whether to use nucleus sampling. If False, use top-k sampling.
+            num_beams (int): Number of beams for beam search. 1 means no beam search.
+            max_length (int): The maximum length of the sequence to be generated.
+            min_length (int): The minimum length of the sequence to be generated.
+            top_p (float): The cumulative probability for nucleus sampling.
+            repetition_penalty (float): The parameter for repetition penalty. 1.0 means no penalty.
+            num_captions (int): Number of captions to be generated for each image.
+        Returns:
+            captions (list): A list of strings of length batch_size * num_captions.
+        """
+        image = samples["image"]
+        with self.maybe_autocast():
+            image_embeds = self.ln_vision(self.visual_encoder(image))
+            image_atts = torch.ones(image_embeds.size()[:-1], dtype=torch.long).to(
+                image.device
+            )
+
+            query_tokens = self.query_tokens.expand(image_embeds.shape[0], -1, -1)
+            query_output = self.Qformer.bert(
+                query_embeds=query_tokens,
+                encoder_hidden_states=image_embeds,
+                encoder_attention_mask=image_atts,
+                return_dict=True,
+            )
+
+            inputs_opt = self.opt_proj(query_output.last_hidden_state)
+            atts_opt = torch.ones(inputs_opt.size()[:-1], dtype=torch.long).to(
+                image.device
+            )
+
+            if "prompt" in samples.keys():
+                prompt = samples["prompt"]
+            else:
+                prompt = self.prompt
+
+            prompt = [prompt] * image.size(0)
+
+            opt_tokens = self.opt_tokenizer(
+                prompt,
+                return_tensors="pt",
+                padding="longest",
+                truncation=True,
+                max_length=self.max_txt_len,
+            ).to(image.device)
+            attention_mask = torch.cat([atts_opt, opt_tokens.attention_mask], dim=1)
+            
+            # new version for transformers>=4.27
+            inputs_embeds = self.opt_model.get_input_embeddings()(opt_tokens.input_ids)
+            inputs_embeds = torch.cat([inputs_opt,inputs_embeds],dim=1)
+            
+            outputs = self.opt_model.generate(
+                inputs_embeds=inputs_embeds, 
+                attention_mask=attention_mask,
+                do_sample=use_nucleus_sampling,
+                top_p=top_p,
+                temperature=temperature,
+                num_beams=num_beams,
+                max_length=max_length,
+                min_length=min_length,
+                eos_token_id=self.eos_token_id,
+                repetition_penalty=repetition_penalty,
+                length_penalty=length_penalty,
+                num_return_sequences=num_captions,
+            )
+            output_text = self.opt_tokenizer.batch_decode(
+                outputs, skip_special_tokens=True
+            )
+                            
+            # previous version for transformers<4.27
+            # if use_nucleus_sampling:
+            #     query_embeds = inputs_opt.repeat_interleave(num_captions, dim=0)
+            #     num_beams = 1
+            # else:
+            #     query_embeds = inputs_opt.repeat_interleave(num_beams, dim=0)
+
+            # outputs = self.opt_model.generate(
+            #     input_ids=input_ids,
+            #     query_embeds=query_embeds,
+            #     attention_mask=attention_mask,
+            #     do_sample=use_nucleus_sampling,
+            #     top_p=top_p,
+            #     temperature=temperature,
+            #     num_beams=num_beams,
+            #     max_new_tokens=max_length,
+            #     min_length=min_length,
+            #     eos_token_id=self.eos_token_id,
+            #     repetition_penalty=repetition_penalty,
+            #     length_penalty=length_penalty,
+            #     num_return_sequences=num_captions,
+            # )
+
+            # prompt_length = opt_tokens.input_ids.shape[1]
+            # output_text = self.opt_tokenizer.batch_decode(
+            #     outputs[:, prompt_length:], skip_special_tokens=True
+            # )
+            
+            output_text = [text.strip() for text in output_text]
+            return output_text
+        
+        
+    def predict_answers(
+        self,
+        samples,
+        num_beams=5,
+        inference_method="generate",
+        max_len=10,
+        min_len=1,
+        num_ans_candidates=128,
+        answer_list=None,
+        prompt="",
+        length_penalty=0,
+        **kwargs
+    ):
+        image = samples["image"]
+        with self.maybe_autocast():
+            image_embeds = self.ln_vision(self.visual_encoder(image))
+            image_atts = torch.ones(image_embeds.size()[:-1], dtype=torch.long).to(
+                image.device
+            )
+
+            query_tokens = self.query_tokens.expand(image_embeds.shape[0], -1, -1)
+            query_output = self.Qformer.bert(
+                query_embeds=query_tokens,
+                encoder_hidden_states=image_embeds,
+                encoder_attention_mask=image_atts,
+                return_dict=True,
+            )
+
+            inputs_opt = self.opt_proj(query_output.last_hidden_state)
+            atts_opt = torch.ones(inputs_opt.size()[:-1], dtype=torch.long).to(
+                image.device
+            )
+
+            if isinstance(samples["text_input"], str):
+                samples["text_input"] = [samples["text_input"]]
+            if prompt:
+                text_input = [prompt.format(question) for question in samples["text_input"]]
+            else:
+                text_input = samples["text_input"]
+
+            self.opt_tokenizer.padding_side = "left"
+            opt_tokens = self.opt_tokenizer(
+                text_input,
+                return_tensors="pt",
+                padding="longest",
+                truncation=True,
+                max_length=self.max_txt_len,
+            ).to(image.device)
+        
+            attention_mask = torch.cat([atts_opt, opt_tokens.attention_mask], dim=1)
+            
+            # require transformers>=4.27
+            inputs_embeds = self.opt_model.get_input_embeddings()(opt_tokens.input_ids)
+            inputs_embeds = torch.cat([inputs_opt,inputs_embeds],dim=1)
+            
+            outputs = self.opt_model.generate(
+                inputs_embeds=inputs_embeds,
+                attention_mask=attention_mask,
+                do_sample=False,
+                num_beams=num_beams,
+                max_new_tokens=max_len,
+                min_length=min_len,
+                eos_token_id=self.eos_token_id,
+                length_penalty=length_penalty,
+            )
+            output_text = self.opt_tokenizer.batch_decode(
+                outputs, skip_special_tokens=True
+            )
+            output_text = [text.strip() for text in output_text]
+        if self._apply_lemmatizer or ("apply_lemmatizer" in samples.keys() and samples["apply_lemmatizer"]):
+            output_text = self._lemmatize(output_text)
+
+        return output_text
+    
+    def _lemmatize(self, answers):
+        def apply(answer):
+            doc = self.lemmatizer(answer)
+
+            words = []
+            for token in doc:
+                if token.pos_ in ["NOUN", "VERB"]:
+                    words.append(token.lemma_)
+                else:
+                    words.append(token.text)
+            answer = " ".join(words)
+
+            return answer
+
+        return [apply(answer) for answer in answers]
+
+    @property
+    def lemmatizer(self):
+        if self._lemmatizer is None:
+            try:
+                import spacy
+
+                self._lemmatizer = spacy.load("en_core_web_sm")
+            except ImportError:
+                logging.error(
+                    """
+                    Please install spacy and en_core_web_sm model to apply lemmatization.
+                    python -m spacy download en_core_web_sm
+                    OR
+                    import spacy.cli
+                    spacy.cli.download("en_core_web_sm")
+                    """
+                )
+                exit(1)
+
+        return self._lemmatizer
+        
+    @classmethod
+    def from_config(cls, cfg):
+        vit_model = cfg.get("vit_model", "eva_clip_g")
+        img_size = cfg.get("image_size")
+        num_query_token = cfg.get("num_query_token")
+        llm_model = cfg.get("llm_model")
+
+        drop_path_rate = cfg.get("drop_path_rate", 0)
+        use_grad_checkpoint = cfg.get("use_grad_checkpoint", False)
+        vit_precision = cfg.get("vit_precision", "fp16")
+        freeze_vit = cfg.get("freeze_vit", True)
+
+        prompt = cfg.get("prompt", "")
+        max_txt_len = cfg.get("max_txt_len", 32)
+        
+        apply_lemmatizer = cfg.get("apply_lemmatizer", False)
+
+        model = cls(
+            vit_model=vit_model,
+            img_size=img_size,
+            drop_path_rate=drop_path_rate,
+            use_grad_checkpoint=use_grad_checkpoint,
+            vit_precision=vit_precision,
+            freeze_vit=freeze_vit,
+            num_query_token=num_query_token,
+            llm_model=llm_model,
+            prompt=prompt,
+            max_txt_len=max_txt_len,
+            apply_lemmatizer=apply_lemmatizer,
+        )
+        model.load_checkpoint_from_config(cfg)
+
+        return model

--- a/lavis/projects/blip2/eval/caption_coco_llama3.1_eval.yaml
+++ b/lavis/projects/blip2/eval/caption_coco_llama3.1_eval.yaml
@@ -1,0 +1,37 @@
+# BLIP-2 LLaMA 3.1 evaluation on COCO Captions
+
+model:
+  arch: blip2_llama
+  model_type: pretrain_llama3.1
+  use_grad_checkpoint: False
+
+datasets:
+  coco_caption:
+    vis_processor:
+        eval:
+          name: "blip_image_eval"
+          image_size: 364
+    text_processor:
+        eval:
+          name: "blip_caption"
+
+run:
+  task: captioning
+  batch_size_train: 32
+  batch_size_eval: 16
+  num_workers: 4
+
+  max_len: 30
+  min_len: 8
+  num_beams: 5
+
+  seed: 42
+  output_dir: "output/BLIP2/Caption_coco_llama3.1"
+
+  evaluate: True
+  test_splits: ["test"]
+
+  device: "cuda"
+  world_size: 1
+  dist_url: "env://"
+  distributed: True

--- a/lavis/projects/blip2/eval/vqav2_llama3.1_eval.yaml
+++ b/lavis/projects/blip2/eval/vqav2_llama3.1_eval.yaml
@@ -1,0 +1,39 @@
+# BLIP-2 LLaMA 3.1 evaluation on VQA v2
+model:
+  arch: blip2_llama
+  model_type: pretrain_llama3.1
+  use_grad_checkpoint: False
+
+datasets:
+  coco_vqa:
+    type: eval
+    vis_processor:
+        eval:
+          name: "blip_image_eval"
+          image_size: 224
+    text_processor:
+        eval:
+          name: "blip_question"
+
+run:
+  task: vqa
+  batch_size_train: 16
+  batch_size_eval: 64
+  num_workers: 4
+
+  max_len: 10
+  min_len: 1
+  num_beams: 5
+  inference_method: "generate"
+  prompt: "Question: {} Short answer:"
+
+  seed: 42
+  output_dir: "output/BLIP2/VQA_llama3.1"
+
+  evaluate: True
+  test_splits: ["val"]
+
+  device: "cuda"
+  world_size: 1
+  dist_url: "env://"
+  distributed: True

--- a/lavis/projects/blip2/train/pretrain_stage2.yaml
+++ b/lavis/projects/blip2/train/pretrain_stage2.yaml
@@ -4,8 +4,8 @@
  # For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
 
 model:
-  arch: blip2_opt
-  model_type: pretrain_opt2.7b 
+  arch: blip2_llama
+  model_type: pretrain_llama3.1
   load_pretrained: True
   # intialize stage 2 pretraining from stage 1 pretrained model
   pretrained: "https://storage.googleapis.com/sfr-vision-language-research/LAVIS/models/BLIP2/blip2_pretrained.pth"

--- a/lavis/projects/blip2/train/vqav2_llama3.1_ft.yaml
+++ b/lavis/projects/blip2/train/vqav2_llama3.1_ft.yaml
@@ -1,0 +1,66 @@
+# Copyright (c) 2022, salesforce.com, inc.
+# All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+# For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+
+model:
+  arch: blip2_llama
+  model_type: pretrain_llama3.1
+  load_finetuned: False
+  freeze_vit: False
+  image_size: 480
+
+datasets:
+  coco_vqa:
+    vis_processor:
+        train:
+          name: "blip_image_train"
+          image_size: 480
+        eval:
+          name: "blip_image_eval"
+          image_size: 480
+    text_processor:
+        train:
+          name: "blip_question"
+        eval:
+          name: "blip_question"
+  vg_vqa:
+    vis_processor:
+        train:
+          name: "blip_image_train"
+          image_size: 480
+    text_processor:
+        train:
+          name: "blip_question"
+
+run:
+  task: vqa
+  lr_sched: "linear_warmup_cosine_lr"
+  init_lr: 2e-5
+  min_lr: 0
+  weight_decay: 0.05
+  max_epoch: 10
+  batch_size_train: 16
+  batch_size_eval: 64
+  num_workers: 4
+
+  max_len: 10
+  min_len: 1
+  num_beams: 3
+  num_ans_candidates: 128
+  inference_method: "rank"
+
+  seed: 42
+  output_dir: "output/BLIP2/VQA_llama3.1"
+
+  amp: True
+  resume_ckpt_path: null
+
+  evaluate: False
+  train_splits: ["train"]
+  test_splits: ["test"]
+
+  device: "cuda"
+  world_size: 1
+  dist_url: "env://"
+  distributed: True

--- a/run_scripts/blip2/eval/eval_llama3.1.sh
+++ b/run_scripts/blip2/eval/eval_llama3.1.sh
@@ -1,0 +1,2 @@
+python -m torch.distributed.run --nproc_per_node=8 evaluate.py --cfg-path lavis/projects/blip2/eval/caption_coco_llama3.1_eval.yaml
+

--- a/run_scripts/blip2/eval/eval_vqav2_llama3.1.sh
+++ b/run_scripts/blip2/eval/eval_vqav2_llama3.1.sh
@@ -1,0 +1,1 @@
+python -m torch.distributed.run --nproc_per_node=8 evaluate.py --cfg-path lavis/projects/blip2/eval/vqav2_llama3.1_eval.yaml

--- a/run_scripts/blip2/train/train_llama3.1.sh
+++ b/run_scripts/blip2/train/train_llama3.1.sh
@@ -1,0 +1,3 @@
+python -m torch.distributed.run --nproc_per_node=16 train.py --cfg-path lavis/projects/blip2/train/pretrain_stage1.yaml
+python -m torch.distributed.run --nproc_per_node=16 train.py --cfg-path lavis/projects/blip2/train/pretrain_stage2.yaml
+

--- a/run_scripts/blip2/train/train_vqav2_llama3.1.sh
+++ b/run_scripts/blip2/train/train_vqav2_llama3.1.sh
@@ -1,0 +1,1 @@
+python -m torch.distributed.run --nproc_per_node=16 train.py --cfg-path lavis/projects/blip2/train/vqav2_llama3.1_ft.yaml


### PR DESCRIPTION
## Summary
- implement `blip2_llama` model to load LLaMA checkpoints
- add config for LLaMA 3.1 pretraining
- update model registry and training config to use the new model
- add scripts to train BLIP‑2 with LLaMA 3.1 and evaluate on COCO captions
- add VQA v2 fine‑tuning config and scripts for LLaMA 3.1

## Testing
- `pre-commit` *(fails: Package 'black' requires a different Python: 3.8.20 not in '>=3.9')*

------
https://chatgpt.com/codex/tasks/task_e_684aa3fd01088330a259a7513a94bb7e